### PR TITLE
fix: include SUPABASE_SERVICE_ROLE in environment check

### DIFF
--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,4 +1,5 @@
 export const isSupabaseEnabled = Boolean(
   process.env.NEXT_PUBLIC_SUPABASE_URL &&
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY &&
+    process.env.SUPABASE_SERVICE_ROLE
 )


### PR DESCRIPTION
## Summary
Fixes auth callback error when SUPABASE_SERVICE_ROLE is missing.

## Problem
The `isSupabaseEnabled` check only validated:
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`

But `createGuestServerClient()` also requires `SUPABASE_SERVICE_ROLE`, causing the error:
```
Error: Missing Supabase environment variables
```

## Solution
Updated `isSupabaseEnabled` to also check for `SUPABASE_SERVICE_ROLE` to ensure all required environment variables are present before attempting to create Supabase clients.

## Test plan
- [ ] Auth callback works when all three environment variables are set
- [ ] Auth callback shows proper error message when any variable is missing

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Add SUPABASE_SERVICE_ROLE to isSupabaseEnabled check to ensure all required environment variables are validated before creating a Supabase client