### PR TITLE
docs: clarify SUPABASE_SERVICE_ROLE environment variable name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ NEXT_PUBLIC_APP_DOMAIN=https://okie.one
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-SUPABASE_SERVICE_ROLE=your_supabase_service_role_key
+SUPABASE_SERVICE_ROLE=your_supabase_service_role_key  # Note: Use SUPABASE_SERVICE_ROLE, not SUPABASE_SERVICE_ROLE_KEY
 
 # CSRF Protection (required)
 # Generate with: openssl rand -base64 32 | tr -dc 'A-Za-z0-9' | head -c32

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ First, you'll need to set up your environment variables. Create a `.env.local` f
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-SUPABASE_SERVICE_ROLE=your_supabase_service_role_key
+SUPABASE_SERVICE_ROLE=your_supabase_service_role_key  # Must be SUPABASE_SERVICE_ROLE, not SUPABASE_SERVICE_ROLE_KEY
 
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION
## Summary
Clarifies that the environment variable must be named `SUPABASE_SERVICE_ROLE`, not `SUPABASE_SERVICE_ROLE_KEY`.

## Problem
Users may mistakenly use `SUPABASE_SERVICE_ROLE_KEY` as the environment variable name, which causes auth callback errors since the code looks for `SUPABASE_SERVICE_ROLE`.

## Solution
Added clear notes in:
- `.env.example`
- `INSTALL.md`

To explicitly state the correct environment variable name.

## Related Issue
This complements the fix in PR #65 which ensures all required environment variables are checked.

🤖 Generated with [Claude Code](https://claude.ai/code)