### PR TITLE
feat: support SUPABASE_SERVICE_ROLE_KEY from Supabase Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ NEXT_PUBLIC_APP_DOMAIN=https://okie.one
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+# Both SUPABASE_SERVICE_ROLE_KEY (from Supabase Integration) and SUPABASE_SERVICE_ROLE are supported
+# If using Supabase Integration on Vercel, it provides SUPABASE_SERVICE_ROLE_KEY automatically
 SUPABASE_SERVICE_ROLE=your_supabase_service_role_key
 
 # CSRF Protection (required)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,7 @@ First, you'll need to set up your environment variables. Create a `.env.local` f
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+# Both SUPABASE_SERVICE_ROLE_KEY (Vercel Integration) and SUPABASE_SERVICE_ROLE are supported
 SUPABASE_SERVICE_ROLE=your_supabase_service_role_key
 
 # OpenAI

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,4 +1,5 @@
 export const isSupabaseEnabled = Boolean(
   process.env.NEXT_PUBLIC_SUPABASE_URL &&
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY &&
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE)
 )

--- a/lib/supabase/server-guest.ts
+++ b/lib/supabase/server-guest.ts
@@ -8,7 +8,8 @@ export async function createGuestServerClient() {
   }
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseServiceRole = process.env.SUPABASE_SERVICE_ROLE
+  // Support both SUPABASE_SERVICE_ROLE_KEY (from Supabase Integration) and SUPABASE_SERVICE_ROLE
+  const supabaseServiceRole = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE
 
   if (!supabaseUrl || !supabaseServiceRole) {
     throw new Error("Missing Supabase environment variables")


### PR DESCRIPTION
## Summary
Adds support for `SUPABASE_SERVICE_ROLE_KEY` environment variable provided by Supabase Integration on Vercel, while maintaining backward compatibility with `SUPABASE_SERVICE_ROLE`.

## Problem
- Supabase Integration on Vercel automatically provides `SUPABASE_SERVICE_ROLE_KEY`
- The app was only looking for `SUPABASE_SERVICE_ROLE`, causing auth callback errors
- Users had to manually rename the environment variable

## Solution
1. Updated `createGuestServerClient()` to check for both:
   - `SUPABASE_SERVICE_ROLE_KEY` (prioritized for Supabase Integration)
   - `SUPABASE_SERVICE_ROLE` (for backward compatibility)

2. Updated `isSupabaseEnabled` to validate that at least one of these variables exists

3. Added documentation explaining both variables are supported

## Changes
- `lib/supabase/server-guest.ts`: Support both env var names
- `lib/supabase/config.ts`: Check for either env var in validation
- `.env.example`: Document both options
- `INSTALL.md`: Explain Vercel Integration compatibility

## Test plan
- [ ] Auth works with `SUPABASE_SERVICE_ROLE_KEY` (Vercel Integration)
- [ ] Auth works with `SUPABASE_SERVICE_ROLE` (manual setup)
- [ ] Proper error when neither variable is set

Closes the issue mentioned in the original auth callback error.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Add support for the SUPABASE_SERVICE_ROLE_KEY environment variable provided by Supabase Integration on Vercel while retaining fallback to the existing SUPABASE_SERVICE_ROLE variable

New Features:
- Prioritize SUPABASE_SERVICE_ROLE_KEY and fall back to SUPABASE_SERVICE_ROLE in createGuestServerClient
- Extend isSupabaseEnabled to require either SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SERVICE_ROLE

Documentation:
- Document support for both SUPABASE_SERVICE_ROLE_KEY and SUPABASE_SERVICE_ROLE in .env.example and INSTALL.md