### PR TITLE
fix: handle useMessages hook outside MessagesProvider context in settings modal

### DIFF
--- a/app/components/layout/settings/general/account-management.tsx
+++ b/app/components/layout/settings/general/account-management.tsx
@@ -2,23 +2,29 @@
 
 import { SignOut } from "@phosphor-icons/react"
 import { useRouter } from "next/navigation"
+import { useContext } from "react"
 
 import { Button } from "@/components/ui/button"
 import { toast } from "@/components/ui/toast"
 import { useChats } from "@/lib/chat-store/chats/provider"
-import { useMessages } from "@/lib/chat-store/messages/provider"
+import { MessagesContext } from "@/lib/chat-store/messages/provider"
 import { clearAllIndexedDBStores } from "@/lib/chat-store/persist"
 import { useUser } from "@/lib/user-store/provider"
 
 export function AccountManagement() {
   const { signOut } = useUser()
   const { resetChats } = useChats()
-  const { resetMessages } = useMessages()
+  // Check if we're within a MessagesProvider context
+  const messagesContext = useContext(MessagesContext)
+  const { resetMessages } = messagesContext || {}
   const router = useRouter()
 
   const handleSignOut = async () => {
     try {
-      await resetMessages()
+      // Only reset messages if we have access to the context
+      if (resetMessages) {
+        await resetMessages()
+      }
       await resetChats()
       await signOut()
       await clearAllIndexedDBStores()

--- a/lib/chat-store/messages/provider.tsx
+++ b/lib/chat-store/messages/provider.tsx
@@ -27,7 +27,7 @@ interface MessagesContextType {
   setHasActiveChatSession: (active: boolean) => void
 }
 
-const MessagesContext = createContext<MessagesContextType | null>(null)
+export const MessagesContext = createContext<MessagesContextType | null>(null)
 
 export function useMessages() {
   const context = useContext(MessagesContext)


### PR DESCRIPTION
## Summary
- Fixed runtime error when opening settings modal by handling missing MessagesProvider context
- Made messages reset optional during sign out when context is not available
- Exported MessagesContext to allow checking for its presence

## Problem
The settings modal is rendered at the root layout level, outside of page-specific MessagesProvider contexts. When the AccountManagement component tries to use the `useMessages` hook, it throws an error because the required context is not available.

## Solution
- Export MessagesContext from the messages provider
- Update AccountManagement component to check if it's within a MessagesProvider context
- Only reset messages during sign out if the context is available

## Test Plan
- [x] Settings modal opens without errors
- [x] Sign out functionality still works correctly
- [x] No TypeScript errors
- [x] Linting passes

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

## Summary by Sourcery

Guard against missing MessagesProvider context in the settings modal by exporting and checking MessagesContext before resetting messages

Bug Fixes:
- Prevent runtime error in AccountManagement by handling absence of MessagesProvider context
- Make messages reset during sign out conditional on MessagesContext availability

Enhancements:
- Export MessagesContext from the messages provider