### PR TITLE
fix: remove fail-on-cache-miss to prevent CI cache dependency failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -208,7 +208,7 @@ jobs:
           restore-keys: |
             deps-${{ hashFiles('**/pnpm-lock.yaml') }}
             deps-
-          fail-on-cache-miss: true
+          fail-on-cache-miss: false
 
       - name: Cache TypeScript
         uses: actions/cache@v4
@@ -261,7 +261,7 @@ jobs:
           restore-keys: |
             deps-${{ hashFiles('**/pnpm-lock.yaml') }}
             deps-
-          fail-on-cache-miss: true
+          fail-on-cache-miss: false
 
       - name: Cache Vitest
         uses: actions/cache@v4


### PR DESCRIPTION
- Set fail-on-cache-miss to false in lint-typescript and test jobs
- Allows CI to continue even when cache keys don't match exactly
- Fixes cache restoration issues in dependabot PRs

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

CI:
- Set fail-on-cache-miss to false for dependency caches in lint-typescript and test jobs